### PR TITLE
Added support of default model

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,19 @@ Namespace to load models from, defaults to `$moniker::Model`.
 
 Base classes used to identify models, defaults to [MojoX::Model](https://metacpan.org/pod/MojoX::Model).
 
+## default
+
+    # Mojolicious::Lite
+    plugin Model => {default => 'MyModel'};
+
+    any '/' => sub {
+      my $c = shift();
+      $c->model->do(); # used model MyModel
+      # ...
+    }
+
+The name of the default model to use if the name of the current model not specified.
+
 # HELPERS
 
 [Mojolicious::Plugin::Model](https://metacpan.org/pod/Mojolicious::Plugin::Model) implements the following helpers.

--- a/lib/Mojolicious/Plugin/Model.pm
+++ b/lib/Mojolicious/Plugin/Model.pm
@@ -20,6 +20,7 @@ sub register {
     model => sub {
       my ($self, $name) = @_;
 
+      $name = $conf->{default} unless defined($name);
       $name = camelize($name) if $name =~ /^[a-z]/;
 
       my $model;
@@ -148,6 +149,20 @@ Namespace to load models from, defaults to C<$moniker::Model>.
   plugin Model => {base_classes => ['MyApp::Model']};
 
 Base classes used to identify models, defaults to L<MojoX::Model>.
+
+=head2 default
+
+  # Mojolicious::Lite
+  plugin Model => {default => 'MyModel'};
+
+  any '/' => sub {
+    my $c = shift();
+    $c->model->do(); # used model MyModel
+    # ...
+  }
+
+The name of the default model to use if the name of the current model not
+specified.
 
 =head1 HELPERS
 

--- a/t/model-default.t
+++ b/t/model-default.t
@@ -1,0 +1,32 @@
+use strict;
+use warnings;
+
+use Test::Mojo;
+use Test::More;
+
+use Mojolicious::Lite;
+
+my $v;
+
+plugin 'Model' => {
+  namespaces => ['Local'],
+  default    => 'MyModel',
+};
+
+get '/' => sub {
+  my $c = shift();
+  ok ref($c->model) eq 'Local::MyModel';
+  $c->rendered(201);
+};
+
+my $t = Test::Mojo->new;
+
+$t->get_ok('/');
+
+done_testing;
+
+package Local::MyModel;
+
+use base 'MojoX::Model';
+
+1;


### PR DESCRIPTION
```
# app
plugin Model => {default => 'MyModel'};

any '/' => sub {
    my $c = shift();
    $c->model->do(); # used model MyModel
    # ...
}
```
